### PR TITLE
Allow module to be installed with any PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,17 @@
     "authors": [
         {
           "name": "Juergen Schreck, Solvature Inc.",
-          "homepage": "http:s//www.solvature.us/",
+          "homepage": "https://www.solvature.us/",
           "email": "info@solvature.us"
+        },
+        {
+          "name": "Todd Hainsworth",
+          "homepage": "https://www.aligent.com.au/",
+          "email": "todd.hainsworth@aligent.com.au"
         }
     ],
-    "require": {
-      "php": "~5.5.22|~5.6.0|7.0.2|7.0.4|~7.0.6"
-    },
     "autoload": {
-	  "psr-4": { "Solvature\\GoogleTrustedStores\\": "" },
+	  "psr-4": { "Solvature\\GoogleCustomerReviews\\": "" },
       "files": [ "registration.php" ]
     }
 }

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Acl/etc/acl.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="Solvature_GoogleCustomerReviews::settings" title="Solvature Google Customer Reviews" sortOrder="10"/>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
Specifically we wanna use it for 7.2 and now that 5.6 is reaching/has
reached EOL (depending on when you're reading this) it's less important
to support it.

Also add acl.xml to allow the config settings to be seen in admin